### PR TITLE
Implement deletion of installations and nicknaming them

### DIFF
--- a/node/Runner.js
+++ b/node/Runner.js
@@ -766,6 +766,7 @@ function createWindow() {
         }
     });
 
+    // Returns array of indexes with edition, ui name and index.
     ipcMain.handle('getInstallations', async (event, args) => {
         try {
             var systemFiles = fs.readdirSync(path.join(app.getPath('userData'))).filter(file => file.startsWith('deltamod_system-'));
@@ -773,8 +774,18 @@ function createWindow() {
             systemFiles.forEach((file) => {
                 if (file.endsWith('unique')) return;
 
+                let commonName = "";
+                try {
+                    commonName = fs.readFileSync(path.join(app.getPath('userData'), file, '_cname'), 'utf8');
+                }
+                catch {
+                    commonName = "Install #" + (parseInt(file.split('-')[1]) + 1);
+                    fs.writeFileSync(path.join(app.getPath('userData'), file, '_cname'), commonName);
+                }
+
                 installations.push({
                     index: parseInt(file.split('-')[1]),
+                    name: commonName,
                     type: KeyValue.readKVSOfIndex('deltaruneEdition', parseInt(file.split('-')[1]))
                 });
             });
@@ -784,6 +795,14 @@ function createWindow() {
             errorWin('Error getting installations: ' + err.toString());
             return [];
         }
+    });
+
+    // Changes C(ommon)Name of the specified installation.
+    ipcMain.handle('setInstallationCName', async (event, args) => {
+        var index = args[0];
+        var newName = args[1];
+
+        fs.writeFileSync(path.join(app.getPath('userData'), 'deltamod_system-'+index, '_cname'), newName);
     });
 
     ipcMain.handle('changeSystemIndex', async (event, args) => {

--- a/node/Runner.js
+++ b/node/Runner.js
@@ -1151,6 +1151,35 @@ function createWindow() {
         }
     });
 
+    ipcMain.handle('deleteSystemIndex', async (event, args) => {
+        var index = args[0];
+        var pathToDelete = path.join(app.getPath('userData'), 'deltamod_system-' + index);
+
+        if (fs.existsSync(pathToDelete)) {
+            fs.rmdirSync(pathToDelete, { recursive: true });
+        }
+
+        // Now reorder the remaining sysindex
+        var systemFiles = fs.readdirSync(path.join(app.getPath('userData'))).filter(file => file.startsWith('deltamod_system-'));
+        systemFiles.forEach((file) => {
+            var currentIndex = file.split('-')[1];
+            if (currentIndex === 'unique') return;
+
+            var newIndex = parseInt(currentIndex);
+            if (newIndex > index) {
+                newIndex--;
+            }
+
+            var oldPath = path.join(app.getPath('userData'), file);
+            var newPath = path.join(app.getPath('userData'), 'deltamod_system-' + newIndex);
+
+            fs.renameSync(oldPath, newPath);
+        });
+
+        page("installmanager");
+        return true;
+    });
+
 
     setWindow(win);
 }

--- a/node/Runner.js
+++ b/node/Runner.js
@@ -236,11 +236,20 @@ function createWindow() {
             console.error('The specified installation of Deltarune is invalid.');
             threrror = 'The specified installation of Deltarune is invalid.';
         }
+        if (!fs.existsSync(app.getPath('userData') + '/deltamod_system-' + overrideData + '/deltaruneInstall') && overrideData !== '0') {
+            overrideData = '0'; // Only 0 can be valid without a deltaruneInstallù
+            dialog.showMessageBoxSync({
+                type: 'warning',
+                title: 'Invalid Installation Selected',
+                message: 'The specified installation of Deltarune is invalid. Reverting to the default installation.'
+            });
+        }
         setSystemIndex(overrideData);
     }
     else {
         console.log('No system index override found, using default index.');
     }
+
     const partition = 'persist:deltamod'; 
     const ses = session.fromPartition(partition);
 
@@ -1172,6 +1181,7 @@ function createWindow() {
 
     ipcMain.handle('deleteSystemIndex', async (event, args) => {
         var index = args[0];
+        var currentIndex = parseInt(fs.readFileSync(getSystemFile('_sysindex',true), 'utf8'));
         var pathToDelete = path.join(app.getPath('userData'), 'deltamod_system-' + index);
 
         if (fs.existsSync(pathToDelete)) {
@@ -1195,7 +1205,29 @@ function createWindow() {
             fs.renameSync(oldPath, newPath);
         });
 
+        if (currentIndex == index)  {
+            var stop = false;
+            var launchHere = 0;
+            systemFiles.forEach((file) => {
+                var idx = file.split('-')[1];
+                if (idx !== 'unique') return;
+                if (stop) return;
+
+                if (fs.existsSync(path.join(app.getPath('userData'), file, 'deltaruneInstall', 'DELTARUNE.exe'))) {
+                    launchHere = parseInt(idx);
+                    stop = true;
+                }
+            });
+
+            fs.writeFileSync(getSystemFile('_sysindex',true), ""+launchHere);
+
+            app.relaunch(properRelaunch());
+            app.exit();
+            return true;
+        }
+
         page("installmanager");
+
         return true;
     });
 

--- a/node/Runner.js
+++ b/node/Runner.js
@@ -1199,6 +1199,10 @@ function createWindow() {
         return true;
     });
 
+    ipcMain.handle('openInstallationFolder', async (event, args) => {
+        shell.openExternal(getSystemFolderOfIndex('deltaruneInstall', args[0]));
+    });
+
 
     setWindow(win);
 }

--- a/web/index.js
+++ b/web/index.js
@@ -19,6 +19,12 @@ window.preloadAPI.onDDS((info) => {
     }
 });
 
+function sanitizeHTML(str) {
+    var temp = document.createElement('div');
+    temp.textContent = str;
+    return temp.innerHTML;
+}
+
 console.log = function(...arguments) {
     window.electronAPI.invoke('log', [arguments.join(' '), 'LOG', pageN]);
 }

--- a/web/installmanager/index.html
+++ b/web/installmanager/index.html
@@ -3,8 +3,8 @@
     <table>
         <thead>
             <colgroup>
-                <col style="width: 90%;">
-                <col style="width: 10%;">
+                <col style="width: 85%;">
+                <col style="width: 15%;">
             </colgroup>
             <thead>
                 <tr>

--- a/web/installmanager/index.js
+++ b/web/installmanager/index.js
@@ -93,7 +93,7 @@ function countingSake(str) {
         openBtn = adaptForIcons(openBtn);
         openBtn.innerHTML = icon('folder_open', '18px') + '';
         openBtn.onclick = () => {
-            window.electronAPI.invoke('openInstallationFolder', [""+install.index]);
+            window.electronAPI.invoke('openInstallationFolder', [install.index.toString()]);
         }
         buttonsDiv.appendChild(openBtn);
 

--- a/web/installmanager/index.js
+++ b/web/installmanager/index.js
@@ -1,3 +1,7 @@
+function countingSake(str) {
+    return str.replace(/\s+/g, '');
+}
+
 (async() => {
     var installs = await window.electronAPI.invoke('getInstallations', []);
     var index = await window.electronAPI.invoke('getSystemIndex', []);
@@ -6,12 +10,35 @@
         const row = document.createElement('tr');
         const nameCell = document.createElement('td');
         const goCell = document.createElement('td');
+        const buttonsDiv = document.createElement('div');
+
+        buttonsDiv.style.display = 'flex';
+        buttonsDiv.style.gap = '10px';
+        buttonsDiv.style.alignItems = 'center';
+        buttonsDiv.style.justifyContent = 'center';
 
         goCell.style.textAlign = 'center';
 
         console.log(JSON.stringify(install));
 
         const nameContainer = document.createElement('div');
+
+        let editablespan = document.createElement('input');
+        editablespan.type = 'text';
+        editablespan.style.display = 'block';
+        editablespan.style.margin = '0';
+        editablespan.style.height = '22px';
+        editablespan.style.fontSize = '13px';
+        editablespan.value = sanitizeHTML(install.name || `Install #${install.index + 1}`);
+        editablespan.style.cursor = 'text';
+        editablespan.onblur = () => {
+            if (countingSake(editablespan.value.trim()) == "") {
+                window.alert("Installation name cannot be empty.");
+                editablespan.value = `Install #${install.index + 1}`;
+            }
+            install.name = editablespan.value.trim();
+            window.electronAPI.invoke('setInstallationCName', [""+install.index, install.name]);
+        };
 
         let boldName = document.createElement('small');
         boldName.style.display = 'inline-flex';
@@ -21,7 +48,9 @@
         boldName.style.marginBottom = '6px';
         boldName.style.justifyContent = 'left';
         boldName.style.fontWeight = 'normal';
-        boldName.innerHTML = icon('snippet_folder') + " Install no. " + (install.index+1);
+        boldName.innerHTML = icon('snippet_folder');
+        boldName.appendChild(editablespan);
+
         nameContainer.appendChild(boldName);
 
         const details = document.createElement('small');
@@ -34,7 +63,7 @@
         goBtn.style.padding = '8px';
         goBtn.style.textAlign = 'center';
         goBtn = adaptForIcons(goBtn);
-        goBtn.innerHTML = icon('sync_arrow_up', '18px') + ' Switch';
+        goBtn.innerHTML = icon('sync_arrow_up', '18px') + '';
         goBtn.onclick = () => {
             window.electronAPI.invoke('changeSystemIndex', [""+install.index]);
         };
@@ -42,21 +71,23 @@
             goBtn.disabled = true;
             goBtn.style.cursor = 'not-allowed';
             goBtn.style.opacity = '0.3';
-            goBtn.innerHTML = icon('check_circle', '18px') + ' Active';
+            goBtn.innerHTML = icon('check_circle', '18px') + '';
         }
-        goCell.appendChild(goBtn);
+        buttonsDiv.appendChild(goBtn);
 
         let deleteBtn = document.createElement('button');
         deleteBtn.style.padding = '8px';
         deleteBtn.style.textAlign = 'center';
         deleteBtn = adaptForIcons(deleteBtn);
-        deleteBtn.innerHTML = icon('delete', '18px') + ' Delete';
+        deleteBtn.innerHTML = icon('delete', '18px') + '';
         deleteBtn.onclick = () => {
             if (window.confirm(`Are you sure you want to delete this installation? This action cannot be undone.`)) {
                 window.electronAPI.invoke('deleteSystemIndex', [""+install.index]);
             }
         };
-        goCell.appendChild(deleteBtn);
+        buttonsDiv.appendChild(deleteBtn);
+
+        goCell.appendChild(buttonsDiv);
 
         nameCell.appendChild(nameContainer);
 

--- a/web/installmanager/index.js
+++ b/web/installmanager/index.js
@@ -36,9 +36,7 @@
         goBtn = adaptForIcons(goBtn);
         goBtn.innerHTML = icon('sync_arrow_up', '18px') + ' Switch';
         goBtn.onclick = () => {
-            if (window.confirm(`Are you sure you want to switch? Deltamod will reboot.`)) {
-                window.electronAPI.invoke('changeSystemIndex', [""+install.index]);
-            }
+            window.electronAPI.invoke('changeSystemIndex', [""+install.index]);
         };
         if (index == install.index) {
             goBtn.disabled = true;
@@ -47,6 +45,18 @@
             goBtn.innerHTML = icon('check_circle', '18px') + ' Active';
         }
         goCell.appendChild(goBtn);
+
+        let deleteBtn = document.createElement('button');
+        deleteBtn.style.padding = '8px';
+        deleteBtn.style.textAlign = 'center';
+        deleteBtn = adaptForIcons(deleteBtn);
+        deleteBtn.innerHTML = icon('delete', '18px') + ' Delete';
+        deleteBtn.onclick = () => {
+            if (window.confirm(`Are you sure you want to delete this installation? This action cannot be undone.`)) {
+                window.electronAPI.invoke('deleteSystemIndex', [""+install.index]);
+            }
+        };
+        goCell.appendChild(deleteBtn);
 
         nameCell.appendChild(nameContainer);
 

--- a/web/installmanager/index.js
+++ b/web/installmanager/index.js
@@ -79,7 +79,7 @@ function countingSake(str) {
         deleteBtn.style.padding = '4px';
         deleteBtn.style.textAlign = 'center';
         deleteBtn = adaptForIcons(deleteBtn);
-        deleteBtn.innerHTML = icon('delete', '18px') + '';
+        deleteBtn.innerHTML = icon('delete', '18px');
         deleteBtn.onclick = () => {
             if (window.confirm(`Are you sure you want to delete this installation? This action cannot be undone.`)) {
                 window.electronAPI.invoke('deleteSystemIndex', [""+install.index]);

--- a/web/installmanager/index.js
+++ b/web/installmanager/index.js
@@ -37,7 +37,7 @@ function countingSake(str) {
                 editablespan.value = `Install #${install.index + 1}`;
             }
             install.name = editablespan.value.trim();
-            window.electronAPI.invoke('setInstallationCName', [""+install.index, install.name]);
+            window.electronAPI.invoke('setInstallationCName', [install.index.toString(), install.name]);
         };
 
         let boldName = document.createElement('small');

--- a/web/installmanager/index.js
+++ b/web/installmanager/index.js
@@ -60,7 +60,7 @@ function countingSake(str) {
         nameContainer.appendChild(details);
 
         let goBtn = document.createElement('button');
-        goBtn.style.padding = '8px';
+        goBtn.style.padding = '4px';
         goBtn.style.textAlign = 'center';
         goBtn = adaptForIcons(goBtn);
         goBtn.innerHTML = icon('sync_arrow_up', '18px') + '';
@@ -76,7 +76,7 @@ function countingSake(str) {
         buttonsDiv.appendChild(goBtn);
 
         let deleteBtn = document.createElement('button');
-        deleteBtn.style.padding = '8px';
+        deleteBtn.style.padding = '4px';
         deleteBtn.style.textAlign = 'center';
         deleteBtn = adaptForIcons(deleteBtn);
         deleteBtn.innerHTML = icon('delete', '18px') + '';
@@ -86,6 +86,16 @@ function countingSake(str) {
             }
         };
         buttonsDiv.appendChild(deleteBtn);
+
+        let openBtn = document.createElement('button');
+        openBtn.style.padding = '4px';
+        openBtn.style.textAlign = 'center';
+        openBtn = adaptForIcons(openBtn);
+        openBtn.innerHTML = icon('folder_open', '18px') + '';
+        openBtn.onclick = () => {
+            window.electronAPI.invoke('openInstallationFolder', [""+install.index]);
+        }
+        buttonsDiv.appendChild(openBtn);
 
         goCell.appendChild(buttonsDiv);
 

--- a/web/installmanager/index.js
+++ b/web/installmanager/index.js
@@ -1,7 +1,3 @@
-function countingSake(str) {
-    return str.replace(/\s+/g, '');
-}
-
 (async() => {
     var installs = await window.electronAPI.invoke('getInstallations', []);
     var index = await window.electronAPI.invoke('getSystemIndex', []);
@@ -63,15 +59,15 @@ function countingSake(str) {
         goBtn.style.padding = '4px';
         goBtn.style.textAlign = 'center';
         goBtn = adaptForIcons(goBtn);
-        goBtn.innerHTML = icon('sync_arrow_up', '18px') + '';
+        goBtn.innerHTML = icon('sync_arrow_up', '18px');
         goBtn.onclick = () => {
-            window.electronAPI.invoke('changeSystemIndex', [""+install.index]);
+            window.electronAPI.invoke('changeSystemIndex', [install.index.toString()]);
         };
         if (index == install.index) {
             goBtn.disabled = true;
             goBtn.style.cursor = 'not-allowed';
             goBtn.style.opacity = '0.3';
-            goBtn.innerHTML = icon('check_circle', '18px') + '';
+            goBtn.innerHTML = icon('check_circle', '18px');
         }
         buttonsDiv.appendChild(goBtn);
 
@@ -81,7 +77,7 @@ function countingSake(str) {
         deleteBtn = adaptForIcons(deleteBtn);
         deleteBtn.innerHTML = icon('delete', '18px');
         deleteBtn.onclick = () => {
-            if (window.confirm(`Are you sure you want to delete this installation? This action cannot be undone.`)) {
+            if (window.confirm("Are you sure you want to delete this installation? This action cannot be undone.")) {
                 window.electronAPI.invoke('deleteSystemIndex', [install.index.toString()]);
             }
         };
@@ -91,7 +87,7 @@ function countingSake(str) {
         openBtn.style.padding = '4px';
         openBtn.style.textAlign = 'center';
         openBtn = adaptForIcons(openBtn);
-        openBtn.innerHTML = icon('folder_open', '18px') + '';
+        openBtn.innerHTML = icon('folder_open', '18px');
         openBtn.onclick = () => {
             window.electronAPI.invoke('openInstallationFolder', [install.index.toString()]);
         }

--- a/web/installmanager/index.js
+++ b/web/installmanager/index.js
@@ -32,7 +32,7 @@ function countingSake(str) {
         editablespan.value = sanitizeHTML(install.name || `Install #${install.index + 1}`);
         editablespan.style.cursor = 'text';
         editablespan.onblur = () => {
-            if (countingSake(editablespan.value.trim()) == "") {
+            if (editablespan.value.trim() === "") {
                 window.alert("Installation name cannot be empty.");
                 editablespan.value = `Install #${install.index + 1}`;
             }

--- a/web/installmanager/index.js
+++ b/web/installmanager/index.js
@@ -82,7 +82,7 @@ function countingSake(str) {
         deleteBtn.innerHTML = icon('delete', '18px');
         deleteBtn.onclick = () => {
             if (window.confirm(`Are you sure you want to delete this installation? This action cannot be undone.`)) {
-                window.electronAPI.invoke('deleteSystemIndex', [""+install.index]);
+                window.electronAPI.invoke('deleteSystemIndex', [install.index.toString()]);
             }
         };
         buttonsDiv.appendChild(deleteBtn);


### PR DESCRIPTION
This does not replace the progressive index system. Instead:
- upon deletion of an installation, all indexes after it are automatically modified by subtracting 1 to account for the lost index.
- it adds a `_cname` file as a _non-unique sysfile_ that holds the actual nickname. The program will generate new `_cname` files for installations that don't have them (pre 1.2) upon entering the Install Manager.