### PR TITLE
Fix erroneous free space check

### DIFF
--- a/node/RunConditions.js
+++ b/node/RunConditions.js
@@ -24,7 +24,8 @@ const conditions = [
         required: true,
         checker: () => {
             const fsp = require("fs");
-            const { bfree, bsize } = fsp.statfsSync(__dirname);
+            const os = require("os");
+            const { bfree, bsize } = fsp.statfsSync(os.homedir());
             free = bfree * bsize;
             return free >= 2 * 1024 * 1024 * 1024;
         }


### PR DESCRIPTION
Fixes https://github.com/deltamodders/deltamod/issues/59 by actually checking `$HOME` instead of checking `__dirname`, which will not work on an AppImage's SquashFS mount