### PR TITLE
Mark Wine check as not required

### DIFF
--- a/node/RunConditions.js
+++ b/node/RunConditions.js
@@ -31,7 +31,7 @@ const conditions = [
     },
     {
         name: 'Wine (if running on Linux)',
-        required: true,
+        required: false,
         checker: () => {
             if (process.platform === 'linux') {
                 const { execSync } = require('child_process');


### PR DESCRIPTION
Deltamod should NOT be relying on the distro's system Wine installation for even starting the launcher, since the game can be run with Proton instead. For non-steam paths this will require a dedicated config option to set the Wine binary path later.