### PR TITLE
Remove the hard-coded GameBanana submission exclusion

### DIFF
--- a/web/views/gamebanana-browse/index.js
+++ b/web/views/gamebanana-browse/index.js
@@ -1,9 +1,5 @@
 let PAGE = (window._pageArguments && window._pageArguments.lp) ? parseInt(window._pageArguments.lp) : 1;
 
-const BLACKLIST_MODS = [
-    493817 // Gendered Kris mod
-];
-
 window.PAGE = PAGE;
 
 window._onClosePage.push(() => {
@@ -212,7 +208,6 @@ async function renderMods(table, GB_API, filter, gameID) {
         for (const mod of data._aRecords) {
             if (mod._sModelName == 'Wip' && !mod._bHasFiles) continue;
             if (mod._sModelName != 'Wip' && mod._sModelName != 'Mod') continue;
-            if (BLACKLIST_MODS.includes(mod._idRow)) continue;
             
             await (async () => {
                 var tr = document.createElement('tr');


### PR DESCRIPTION
## Summary

Remove the hard-coded exclusion of GameBanana mod `493817` from the built-in
mod browser.

## Rationale

`renderMods()` currently discards this submission by ID before rendering it.
The submission remains publicly available on GameBanana and provides files
registered for Deltamod, so it should be evaluated using the same availability
and compatibility checks as other submissions.

Undertale and Deltarune mods often reflect different interpretations of their
characters. Listing a compatible submission does not endorse its interpretation,
and the manager should not silently prefer one interpretation over another.

GameBanana already applies its own platform moderation and content-rating rules.
Deltamod should continue to enforce its technical packaging requirements, while
leaving the choice of which compatible mods to install to the user.

## Changes

- Remove the `BLACKLIST_MODS` constant.
- Remove the associated `_idRow` filter from `renderMods()`.

## Scope

This change does not modify GameBanana moderation, content ratings, download
validation, or Deltamod's package compatibility requirements.

## Verification

- `node --check web/views/gamebanana-browse/index.js`
- `git diff --check origin/develop...HEAD`
- Confirmed that no references to `BLACKLIST_MODS` or `493817` remain in the
  browse view.
- Confirmed that GameBanana currently reports the submission as public and
  provides three files registered for Deltamod.

The Electron UI was not exercised manually.
