### PR TITLE
Fix custom protocol CORS issues on Arch Linux

### DIFF
--- a/node/Runner.js
+++ b/node/Runner.js
@@ -302,6 +302,21 @@ if (!app.requestSingleInstanceLock()) {
     });
 }
 
+protocol.registerSchemesAsPrivileged([
+    {
+        scheme: 'deltapack',
+        privileges: {
+            corsEnabled: true
+        }
+    },
+    {
+        scheme: "themeprot",
+        privileges: {
+            corsEnabled: true
+        }
+    }
+]);
+
 app.whenReady().then(() => {
     if (['win32', 'linux'].includes(process.platform)) {
         const maybeUrl = process.argv.find(arg => arg.startsWith('deltamod://'));


### PR DESCRIPTION
Hi.

When running the git master version of Deltamod (after upgrading Electron with `npm i electron@40` (40.10.6), because older versions won't download for me) (and `npm install-scripts approve electron node-pty`, because otherwise it also won't download), Electron fails to load the theme due to CORS and doesn't load any menus.

```txt
index.html:1 Access to fetch at 'themeprot://data/base.theme.json' from origin 'deltapack://web' has been blocked by CORS policy: Cross origin requests are only supported for protocol schemes: chrome, chrome-extension, chrome-untrusted, data, http, https.
themeprot://data/base.theme.json:1  Failed to load resource: net::ERR_FAILED
index.js:378   Uncaught (in promise) TypeError: Failed to fetch
    at themeRefresh (index.js:378:19)
    at async index.js:663:5
```

Apparently, Electron requires custom protocols to be declared in newer versions or something, but this doesn't happen with the version of Electron bundled in the itch.io zip file (which also doesn't work because of issue #72).

This fixes it (at least for me).