### PR TITLE
Fix adding a DELTARUNE installation

### DIFF
--- a/node/IPCHandlers.js
+++ b/node/IPCHandlers.js
@@ -126,12 +126,13 @@ async function getInstallations(suppressWarnings = false) {
         const index = parseInt(file.split('-')[1], 10);
         const storeJSON = path.join(installPath, 'store.json');
 
+        // TODO: is this a TOC TOU bug?
         var storeData = JSON.parse(fs.existsSync(storeJSON) ? fs.readFileSync(storeJSON, 'utf8') : '{}');
-        const deltaruneInstall = validateDeltarune(storeData.gamePath);
+        const deltaruneInstall = storeData.gamePath ? validateDeltarune(storeData.gamePath) : null;
 
         const cnamePath = path.join(installPath, '_cname');
 
-        if (!fs.existsSync(deltaruneInstall) || !fs.existsSync(storeJSON)) {
+        if (!deltaruneInstall || !fs.existsSync(deltaruneInstall)) {
             const defaultCName = `Install #${index + 1}`;
             const cname = fs.existsSync(cnamePath) ? fs.readFileSync(cnamePath, 'utf8') : defaultCName;
 

--- a/node/KeyValue.js
+++ b/node/KeyValue.js
@@ -11,14 +11,21 @@ function hash(str) {
     return crypto.createHash('sha256').update(str).digest('hex');
 }
 
+/**
+ * Loads `store.json` of current installation into global `kvs`.
+ * Returns whether `store.json` exists.
+ * @returns bool
+ */
 function retrieve() {
     healthCheck();
     var pathname = getSystemFile('store.json', false);
-    if (!fs.existsSync(pathname)) {
-        console.log('Creating blank store');
-        fs.writeFileSync(pathname, '{}');
+    try {
+        var raw = fs.readFileSync(pathname, 'utf8');
+    } catch (e) {
+        if (e.code == "ENOENT")
+            return false;
+        throw e;
     }
-    var raw = fs.readFileSync(pathname, 'utf8');
     kvs = JSON.parse(raw.split('##')[0]);
     console.log('Store loaded')
     return true;

--- a/node/System.js
+++ b/node/System.js
@@ -12,11 +12,6 @@ function generateUniqueId() {
 }
 
 function healthCheck() {
-    if (!fs.existsSync(path.join(app.getPath('userData'), 'deltamod_system-' + systemIndex))) {
-        fs.mkdirSync(path.join(app.getPath('userData'), 'deltamod_system-' + systemIndex), { recursive: true });
-        console.log('Created deltamod_system folder in userData');
-    }
-
     if (!fs.existsSync(path.join(app.getPath('userData'), 'deltamod_system-unique'))) {
         fs.mkdirSync(path.join(app.getPath('userData'), 'deltamod_system-unique'), { recursive: true });
         console.log('Created deltamod_system-unique folder in userData');


### PR DESCRIPTION
This fixes a bunch of stuff:

1. `deltapath` undefined in `validateDeltarune`

band-aid fix for:

```txt
Error occurred in handler for 'createNewInstallation': TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at Object.join (node:path:1339:7)
    at [REDACTED]/node/IPCHandlers.js:110:43
    at Array.every (<anonymous>)
    at validateDeltarune ([REDACTED]/node/IPCHandlers.js:109:30)
    at getInstallations ([REDACTED]/node/IPCHandlers.js:130:34)
    at [REDACTED]/node/IPCHandlers.js:856:24
    at Session.<anonymous> (node:electron/js2c/browser_init:2:115338)
    at Session.emit (node:events:509:28) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

caused by `getInstallations` not checking if an installation has a `gamePath` field and `deltamod_system-0` existing with an empty `store.json` dict for some reason (???)

I deleted the `deltamod` config dir, so I don't know why that dir exists

2. `generateUUID` is not exported from `Utils.js`

3. `i` is undefined in kvs setup in `createNewInstallation`

I'm guessing the intention was to use the UUID, so I changed `i` to `uid`

4. `kvsFlushIndex` doesn't create parent dirs

(this one may be me misinterpreting issue 3)

let me know what to change here