### PR TITLE
fix: pages with gamabanana not working on case-sensitive fs

### DIFF
--- a/web/views/allmods/index.js
+++ b/web/views/allmods/index.js
@@ -302,7 +302,7 @@ async function createErroringMods(errors) {
 }
 
 (async () => {
-    var loggedIn = await window.electronAPI.invoke('isLoggedIn', ['gamebanana']);
+    var loggedIn = await window.electronAPI.invoke('isLoggedIn', ['GameBanana']);
     const errorBanner = document.getElementById("error-banner");
 
     let filterFunc = (x) => true;

--- a/web/views/gamebanana-browse/index.js
+++ b/web/views/gamebanana-browse/index.js
@@ -121,7 +121,7 @@ let isGBLoggedIn = false;
 
 async function gameBananaLogin() {
     const loggedin = await Promise.race([
-        window.electronAPI.invoke('getAccountInfo', ['gamebanana']),
+        window.electronAPI.invoke('getAccountInfo', ['GameBanana']),
         new Promise(resolve => setTimeout(() => resolve(false), 5000))
     ]);
 


### PR DESCRIPTION
On case-sensitive filesystems (`ext4`, `btrfs`, etc. on Linux and `hfs`, `apfs` on macOS (if enabled)) the list was empty since the `allmods` view passed a string with different cap. to the `isLoggedIn` handler, which failed to load the file.

A backend fix would be pretty annoying and would require a readdir, so this is probably better.